### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Team training, drills, and inter-school soccer matches",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Swimming Club": {
+        "description": "Improve swimming techniques and endurance",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore drawing, painting, and mixed media art projects",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["isabella@mergington.edu", "charlotte@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Practice acting, improvisation, and stage performance",
+        "schedule": "Thursdays, 3:30 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+    },
+    "Math Olympiad": {
+        "description": "Solve advanced math problems and prepare for competitions",
+        "schedule": "Mondays, 3:30 PM - 4:30 PM",
+        "max_participants": 16,
+        "participants": ["ethan@mergington.edu", "jacob@mergington.edu"]
+    },
+    "Debate Society": {
+        "description": "Develop critical thinking and public speaking through debates",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["lucas@mergington.edu", "evelyn@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,70 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.participants-title {
+  margin-bottom: 8px;
+  color: #1a237e;
+}
+
+.participants-list {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 6px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background-color: #eef2ff;
+}
+
+.participant-email {
+  overflow-wrap: anywhere;
+  color: #334155;
+}
+
+.participants-list li:last-child {
+  margin-bottom: 0;
+}
+
+.remove-participant-btn {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background-color: white;
+  color: #b91c1c;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  transition: all 0.2s ease;
+}
+
+.remove-participant-btn:hover {
+  border-color: #fca5a5;
+  background-color: #fee2e2;
+}
+
+.participants-list .empty-state {
+  margin-left: 0;
+  color: #64748b;
+  font-style: italic;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import activities, app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    original_state = deepcopy(activities)
+
+    yield
+
+    activities.clear()
+    activities.update(original_state)

--- a/tests/test_activities_api.py
+++ b/tests/test_activities_api.py
@@ -1,0 +1,29 @@
+def test_root_redirects_to_static_index(client):
+    # Arrange
+    endpoint = "/"
+
+    # Act
+    response = client.get(endpoint, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 307
+    assert response.headers["location"] == "/static/index.html"
+
+
+def test_get_activities_returns_expected_structure(client):
+    # Arrange
+    endpoint = "/activities"
+    expected_fields = {"description", "schedule", "max_participants", "participants"}
+
+    # Act
+    response = client.get(endpoint)
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert isinstance(payload, dict)
+    assert len(payload) > 0
+
+    first_activity = next(iter(payload.values()))
+    assert expected_fields.issubset(first_activity.keys())
+    assert isinstance(first_activity["participants"], list)

--- a/tests/test_signup_api.py
+++ b/tests/test_signup_api.py
@@ -1,0 +1,66 @@
+from src.app import activities
+
+
+def test_signup_adds_new_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    new_email = "new.student@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": new_email},
+    )
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert payload["message"] == f"Signed up {new_email} for {activity_name}"
+    assert new_email in activities[activity_name]["participants"]
+
+
+def test_signup_returns_404_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 404
+    assert payload["detail"] == "Activity not found"
+
+
+def test_signup_returns_400_for_already_registered_student(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = "michael@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": existing_email},
+    )
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 400
+    assert payload["detail"] == "Student already signed up for this activity"
+
+
+def test_signup_returns_422_when_email_is_missing(client):
+    # Arrange
+    activity_name = "Chess Club"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup")
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 422
+    assert payload["detail"]

--- a/tests/test_unregister_api.py
+++ b/tests/test_unregister_api.py
@@ -1,0 +1,66 @@
+from src.app import activities
+
+
+def test_unregister_removes_existing_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = "michael@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup",
+        params={"email": existing_email},
+    )
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert payload["message"] == f"Unregistered {existing_email} from {activity_name}"
+    assert existing_email not in activities[activity_name]["participants"]
+
+
+def test_unregister_returns_404_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 404
+    assert payload["detail"] == "Activity not found"
+
+
+def test_unregister_returns_404_for_non_registered_student(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "not.registered@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 404
+    assert payload["detail"] == "Student is not signed up for this activity"
+
+
+def test_unregister_returns_422_when_email_is_missing(client):
+    # Arrange
+    activity_name = "Chess Club"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup")
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 422
+    assert payload["detail"]


### PR DESCRIPTION
This pull request adds support for unregistering participants from activities, improves the UI to display and manage participants, and introduces comprehensive API tests. The main changes are grouped into backend API enhancements, frontend UI updates, and testing improvements.

Backend API enhancements:

* Added a new `unregister_from_activity` endpoint to allow removal of participants from activities, including validation for unknown activities and non-registered students.
* Updated the signup logic to prevent duplicate registrations by checking if a student is already signed up.
* Expanded the `activities` data structure with several new activities and their details.

Frontend UI updates:

* Improved the activities list UI to show participants for each activity, including a remove button for each participant, and added styles for participant management. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L10-R57) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R77-R140)
* Implemented client-side logic to unregister participants via the new API, update the UI after changes, and provide user feedback. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R74-R106) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R148-R163) [[3]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R128)

Testing improvements:

* Added fixtures to reset the activities state between tests for reliable test isolation.
* Introduced new test suites for signup and unregister APIs, covering successful cases and error handling, and validated the structure of the activities API. [[1]](diffhunk://#diff-eafc5698f9b6a7272e496525da3098f0fc56b9c19e4ccb6eaf54108bbac9f0ceR1-R29) [[2]](diffhunk://#diff-82365400182aa66dc856530c1ed177b3dc82f4e49d95368b1bbcd0a37edbe272R1-R66) [[3]](diffhunk://#diff-e41ba8cb253a60c8ff829598dc5cd240b2d1dc03cf85177206d3d69341d8b973R1-R66)